### PR TITLE
Add Linux aarch64 wheel builds and modernize CI

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -45,3 +45,34 @@ jobs:
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.python }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
+
+  build-wheels-linux-aarch64:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python: [cp310, cp311, cp312, cp313, cp314]
+    env:
+      CIBW_BUILD: ${{ matrix.python }}*aarch64
+      CIBW_SKIP: "*-musllinux_*"
+      CIBW_ARCHS_LINUX: aarch64
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: 3.12
+      - name: Install cibuildwheel
+        run: pip install cibuildwheel
+      - name: Build wheels
+        run: cibuildwheel --output-dir wheelhouse
+      - uses: actions/upload-artifact@v7
+        with:
+          name: wheels-linux-aarch64-${{ matrix.python }}
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -4,6 +4,9 @@ on:
   pull_request: {}
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build-wheels:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -11,7 +11,7 @@ jobs:
   
   keep-workflow-alive:
     name: Keep workflow alive
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,13 +59,12 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v7
         with:
-          python-version: 3.9
+          python-version: "3.12"
       - name: Build a source tarball
-        run:
-            python setup.py sdist
+        run: pip install build && python -m build --sdist
       - uses: actions/upload-artifact@v7
         with:
           name: tarball
@@ -85,10 +84,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Set up Python 3.9
+      - name: Set up Python 3.12
         uses: actions/setup-python@v7
         with:
-          python-version: 3.9
+          python-version: "3.12"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
         python -m pip install --upgrade pip setuptools
         pip install tox tox-gh-actions
     - name: Install pandoc  # needed by nbconvert
-      uses: pandoc/actions/setup@main
+      uses: pandoc/actions/setup@v1
       with:
         version: 2.19
     - name: Run tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=64", "versioneer[toml]>=0.29"]
+build-backend = "setuptools.build_meta"
+
 [tool.coverage.run]
 omit = [
     "efel/_version.py"


### PR DESCRIPTION
for https://github.com/openbraininstitute/INFRA/issues/600

- Add QEMU-based aarch64 wheel build job for Linux
- Replace deprecated `python setup.py sdist` with `python -m build --sdist`
- Add [build-system] table to pyproject.toml for PEP 517 compatibility
- Bump Python versions in publish workflow (3.9 → 3.12)
- Bump keep-alive runner from ubuntu-22.04 to ubuntu-24.04
- Pin pandoc/actions/setup from main to v1