### PR TITLE
Use native ARM64 runner for aarch64 wheel builds

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -50,7 +50,7 @@ jobs:
           path: ./wheelhouse/*.whl
 
   build-wheels-linux-aarch64:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
@@ -63,10 +63,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
       - name: Set up Python
         uses: actions/setup-python@v7
         with:


### PR DESCRIPTION
Do not use emulation layer for arm64 builds. This should result in faster CI builds